### PR TITLE
v0.1.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.1.2 (2023-05-13)
+
+### Fixed
+- `timestamp_ms` time unit
+
+### Changed
+- use `circuits_i2c` v2 release candidate in dev and test environment;
+  optiontally in prod
+
 ## v0.1.1 (2023-05-09)
 
 ### Added

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule VEML7700.MixProject do
   use Mix.Project
 
-  @version "0.1.1"
+  @version "0.1.2"
   @description "Use Vishay ambient light sensor VEML7700 in Elixir"
   @source_url "https://github.com/mnishiguchi/veml7700"
   @datasheet_url "https://www.vishay.com/docs/84286/veml7700.pdf"


### PR DESCRIPTION
### Fixed
- `timestamp_ms` time unit

### Changed
- use `circuits_i2c` v2 release candidate in dev and test environment;
  optiontally in prod